### PR TITLE
Fix vole access em

### DIFF
--- a/faest_aes.c
+++ b/faest_aes.c
@@ -1743,47 +1743,61 @@ static void em_enc_backward_128_verify(vbb_t* vbb, const bf128_t* bf_x, const bf
   }
 }
 
-static void em_enc_backward_128_vbb(vbb_t* vbb, const bf128_t* bf_x, vbb_t* vbb_out, uint8_t Mtag,
-                                    uint8_t Mkey, const uint8_t* delta, bf128_t* y_out) {
+static void em_enc_backward_128_vbb_linear_access(vbb_t* vbb, const bf128_t* bf_x, vbb_t* vbb_out,
+                                                  uint8_t Mtag, uint8_t Mkey, const uint8_t* delta,
+                                                  bf128_t* y_out) {
   // Step: 1
   const bf128_t bf_delta = delta ? bf128_load(delta) : bf128_zero();
   const bf128_t factor =
       bf128_mul_bit(bf128_add(bf128_mul_bit(bf_delta, Mkey), bf128_from_bit(1 ^ Mkey)), 1 ^ Mtag);
 
-  for (unsigned int j = 0; j < FAEST_EM_128F_R; j++) {
-    for (unsigned int c = 0; c < FAEST_EM_128F_Nwd; c++) {
-      for (unsigned int r = 0; r <= 3; r++) {
-        bf128_t bf_z_tilde[8];
-        const unsigned int icol = (c - r + FAEST_EM_128F_Nwd) % FAEST_EM_128F_Nwd;
-        const unsigned int ird =
-            FAEST_EM_128F_LAMBDA + 32 * FAEST_EM_128F_Nwd * j + 32 * icol + 8 * r;
+  for (unsigned int chunk_idx = 0; chunk_idx < FAEST_EM_128F_LAMBDA; chunk_idx += 8) {
+    unsigned int j   = FAEST_EM_128F_R - 1;
+    unsigned int ird = chunk_idx + 32 * FAEST_EM_128F_Nwd * (j + 1);
+    unsigned int r   = chunk_idx % 32 / 8;
+    unsigned int c   = ((chunk_idx - 8 * r) / 32 + r) % FAEST_EM_128F_Nwd;
 
-        if (j < (FAEST_EM_128F_R - 1)) {
-          for (unsigned int i = 0; i < 8; i++) {
-            memcpy(bf_z_tilde + i, get_vole_aes_128(vbb, ird + i), sizeof(bf128_t));
-          }
-        } else {
-          for (unsigned int i = 0; i < 8; ++i) {
-            // Step: 12
-            bf_z_tilde[i] = *get_vole_aes_128(vbb_out, ird - 32 * FAEST_EM_128F_Nwd * (j + 1) + i);
-            if (bf_x) {
-              bf_z_tilde[i] = bf128_add(bf_z_tilde[i], bf_x[ird + i]);
-            }
-          }
-        }
-
-        bf128_t bf_y_tilde[8];
-        for (unsigned int i = 0; i < 8; ++i) {
-          bf_y_tilde[i] = bf128_add(bf128_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
-                                    bf_z_tilde[(i + 2) % 8]);
-        }
-        bf_y_tilde[0] = bf128_add(bf_y_tilde[0], factor);
-        bf_y_tilde[2] = bf128_add(bf_y_tilde[2], factor);
-
-        // Step: 18
-        y_out[4 * FAEST_EM_128F_Nwd * j + 4 * c + r] = bf128_byte_combine(bf_y_tilde);
+    bf128_t bf_z_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_z_tilde[i] = *get_vole_aes_128(vbb_out, chunk_idx + i);
+      if (bf_x) {
+        bf_z_tilde[i] = bf128_add(bf_z_tilde[i], bf_x[ird + i]);
       }
     }
+
+    bf128_t bf_y_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_y_tilde[i] = bf128_add(bf128_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
+                                bf_z_tilde[(i + 2) % 8]);
+    }
+    bf_y_tilde[0] = bf128_add(bf_y_tilde[0], factor);
+    bf_y_tilde[2] = bf128_add(bf_y_tilde[2], factor);
+
+    y_out[4 * FAEST_EM_128F_Nwd * j + 4 * c + r] = bf128_byte_combine(bf_y_tilde);
+  }
+
+  for (unsigned int chunk_idx = FAEST_EM_128F_LAMBDA;
+       chunk_idx < FAEST_EM_128F_R * FAEST_EM_128F_Nwd * 4 * 8; chunk_idx += 8) {
+    unsigned int ird = chunk_idx;
+    unsigned int j   = (ird - FAEST_EM_128F_LAMBDA) / (32 * FAEST_EM_128F_Nwd);
+    unsigned int r   = (ird - FAEST_EM_128F_LAMBDA - j * 32 * FAEST_EM_128F_Nwd) % 32 / 8;
+    unsigned int c = ((ird - FAEST_EM_128F_LAMBDA - j * 32 * FAEST_EM_128F_Nwd - 8 * r) / 32 + r) %
+                     FAEST_EM_128F_Nwd;
+
+    bf128_t bf_z_tilde[8];
+    for (unsigned int i = 0; i < 8; i++) {
+      memcpy(bf_z_tilde + i, get_vole_aes_128(vbb, chunk_idx + i), sizeof(bf128_t));
+    }
+
+    bf128_t bf_y_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_y_tilde[i] = bf128_add(bf128_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
+                                bf_z_tilde[(i + 2) % 8]);
+    }
+    bf_y_tilde[0] = bf128_add(bf_y_tilde[0], factor);
+    bf_y_tilde[2] = bf128_add(bf_y_tilde[2], factor);
+
+    y_out[4 * FAEST_EM_128F_Nwd * j + 4 * c + r] = bf128_byte_combine(bf_y_tilde);
   }
 }
 
@@ -1801,7 +1815,7 @@ static void em_enc_constraints_Mkey_0_128(const uint8_t* out, const uint8_t* x, 
   em_enc_forward_128_1(w, x, bf_s);
   em_enc_forward_128_vbb(vbb, NULL, bf_vs);
   em_enc_backward_128_1(w, x, w_out, bf_s_dash);
-  em_enc_backward_128_vbb(vbb, NULL, vbb, 1, 0, NULL, bf_vs_dash);
+  em_enc_backward_128_vbb_linear_access(vbb, NULL, vbb, 1, 0, NULL, bf_vs_dash);
 
   for (unsigned int j = 0; j < FAEST_EM_128F_Senc; j++) {
     const bf128_t tmp = bf128_mul(bf_vs[j], bf_vs_dash[j]);
@@ -2075,47 +2089,61 @@ static void em_enc_backward_192_verify(vbb_t* vbb, const bf192_t* bf_x, const bf
   }
 }
 
-static void em_enc_backward_192_vbb(vbb_t* vbb, const bf192_t* bf_x, vbb_t* vbb_out, uint8_t Mtag,
-                                    uint8_t Mkey, const uint8_t* delta, bf192_t* y_out) {
+static void em_enc_backward_192_vbb_linear_access(vbb_t* vbb, const bf192_t* bf_x, vbb_t* vbb_out,
+                                                  uint8_t Mtag, uint8_t Mkey, const uint8_t* delta,
+                                                  bf192_t* y_out) {
   // Step: 1
   const bf192_t bf_delta = delta ? bf192_load(delta) : bf192_zero();
   const bf192_t factor =
       bf192_mul_bit(bf192_add(bf192_mul_bit(bf_delta, Mkey), bf192_from_bit(1 ^ Mkey)), 1 ^ Mtag);
 
-  for (unsigned int j = 0; j < FAEST_EM_192F_R; j++) {
-    for (unsigned int c = 0; c < FAEST_EM_192F_Nwd; c++) {
-      for (unsigned int r = 0; r <= 3; r++) {
-        bf192_t bf_z_tilde[8];
-        const unsigned int icol = (c - r + FAEST_EM_192F_Nwd) % FAEST_EM_192F_Nwd;
-        const unsigned int ird =
-            FAEST_EM_192F_LAMBDA + 32 * FAEST_EM_192F_Nwd * j + 32 * icol + 8 * r;
+  for (unsigned int chunk_idx = 0; chunk_idx < FAEST_EM_192F_LAMBDA; chunk_idx += 8) {
+    unsigned int j   = FAEST_EM_192F_R - 1;
+    unsigned int ird = chunk_idx + 32 * FAEST_EM_192F_Nwd * (j + 1);
+    unsigned int r   = chunk_idx % 32 / 8;
+    unsigned int c   = ((chunk_idx - 8 * r) / 32 + r) % FAEST_EM_192F_Nwd;
 
-        if (j < (FAEST_EM_192F_R - 1)) {
-          for (unsigned int i = 0; i < 8; i++) {
-            memcpy(bf_z_tilde + i, get_vole_aes_192(vbb, ird + i), sizeof(bf192_t));
-          }
-        } else {
-          for (unsigned int i = 0; i < 8; ++i) {
-            // Step: 12
-            bf_z_tilde[i] = *get_vole_aes_192(vbb_out, ird - 32 * FAEST_EM_192F_Nwd * (j + 1) + i);
-            if (bf_x) {
-              bf_z_tilde[i] = bf192_add(bf_z_tilde[i], bf_x[ird + i]);
-            }
-          }
-        }
-
-        bf192_t bf_y_tilde[8];
-        for (unsigned int i = 0; i < 8; ++i) {
-          bf_y_tilde[i] = bf192_add(bf192_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
-                                    bf_z_tilde[(i + 2) % 8]);
-        }
-        bf_y_tilde[0] = bf192_add(bf_y_tilde[0], factor);
-        bf_y_tilde[2] = bf192_add(bf_y_tilde[2], factor);
-
-        // Step: 18
-        y_out[4 * FAEST_EM_192F_Nwd * j + 4 * c + r] = bf192_byte_combine(bf_y_tilde);
+    bf192_t bf_z_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_z_tilde[i] = *get_vole_aes_192(vbb_out, chunk_idx + i);
+      if (bf_x) {
+        bf_z_tilde[i] = bf192_add(bf_z_tilde[i], bf_x[ird + i]);
       }
     }
+
+    bf192_t bf_y_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_y_tilde[i] = bf192_add(bf192_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
+                                bf_z_tilde[(i + 2) % 8]);
+    }
+    bf_y_tilde[0] = bf192_add(bf_y_tilde[0], factor);
+    bf_y_tilde[2] = bf192_add(bf_y_tilde[2], factor);
+
+    y_out[4 * FAEST_EM_192F_Nwd * j + 4 * c + r] = bf192_byte_combine(bf_y_tilde);
+  }
+
+  for (unsigned int chunk_idx = FAEST_EM_192F_LAMBDA;
+       chunk_idx < FAEST_EM_192F_R * FAEST_EM_192F_Nwd * 4 * 8; chunk_idx += 8) {
+    unsigned int ird = chunk_idx;
+    unsigned int j   = (ird - FAEST_EM_192F_LAMBDA) / (32 * FAEST_EM_192F_Nwd);
+    unsigned int r   = (ird - FAEST_EM_192F_LAMBDA - j * 32 * FAEST_EM_192F_Nwd) % 32 / 8;
+    unsigned int c = ((ird - FAEST_EM_192F_LAMBDA - j * 32 * FAEST_EM_192F_Nwd - 8 * r) / 32 + r) %
+                     FAEST_EM_192F_Nwd;
+
+    bf192_t bf_z_tilde[8];
+    for (unsigned int i = 0; i < 8; i++) {
+      memcpy(bf_z_tilde + i, get_vole_aes_192(vbb, chunk_idx + i), sizeof(bf192_t));
+    }
+
+    bf192_t bf_y_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_y_tilde[i] = bf192_add(bf192_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
+                                bf_z_tilde[(i + 2) % 8]);
+    }
+    bf_y_tilde[0] = bf192_add(bf_y_tilde[0], factor);
+    bf_y_tilde[2] = bf192_add(bf_y_tilde[2], factor);
+
+    y_out[4 * FAEST_EM_192F_Nwd * j + 4 * c + r] = bf192_byte_combine(bf_y_tilde);
   }
 }
 
@@ -2133,7 +2161,7 @@ static void em_enc_constraints_Mkey_0_192(const uint8_t* out, const uint8_t* x, 
   em_enc_forward_192_1(w, x, bf_s);
   em_enc_forward_192_vbb(vbb, NULL, bf_vs);
   em_enc_backward_192_1(w, x, w_out, bf_s_dash);
-  em_enc_backward_192_vbb(vbb, NULL, vbb, 1, 0, NULL, bf_vs_dash);
+  em_enc_backward_192_vbb_linear_access(vbb, NULL, vbb, 1, 0, NULL, bf_vs_dash);
 
   for (unsigned int j = 0; j < FAEST_EM_192F_Senc; j++) {
     const bf192_t tmp = bf192_mul(bf_vs[j], bf_vs_dash[j]);
@@ -2413,50 +2441,68 @@ static void em_enc_backward_256_verify(vbb_t* vbb, const bf256_t* bf_x, const bf
   }
 }
 
-static void em_enc_backward_256_vbb(vbb_t* vbb, const bf256_t* bf_x, vbb_t* vbb_out, uint8_t Mtag,
+static void em_enc_backward_256_vbb_linear_access(vbb_t* vbb, const bf256_t* bf_x, vbb_t* vbb_out, uint8_t Mtag,
                                     uint8_t Mkey, const uint8_t* delta, bf256_t* y_out) {
   // Step: 1
   const bf256_t bf_delta = delta ? bf256_load(delta) : bf256_zero();
   const bf256_t factor =
       bf256_mul_bit(bf256_add(bf256_mul_bit(bf_delta, Mkey), bf256_from_bit(1 ^ Mkey)), 1 ^ Mtag);
 
-  for (unsigned int j = 0; j < FAEST_EM_256F_R; j++) {
-    for (unsigned int c = 0; c < FAEST_EM_256F_Nwd; c++) {
-      for (unsigned int r = 0; r <= 3; r++) {
-        bf256_t bf_z_tilde[8];
-        unsigned int icol = (c - r + FAEST_EM_256F_Nwd) % FAEST_EM_256F_Nwd;
-        if (FAEST_EM_256F_Nwd == 8 && r >= 2) {
-          icol = (icol - 1 + FAEST_EM_256F_Nwd) % FAEST_EM_256F_Nwd;
-        }
-        const unsigned int ird =
-            FAEST_EM_256F_LAMBDA + 32 * FAEST_EM_256F_Nwd * j + 32 * icol + 8 * r;
+  for (unsigned int chunk_idx = 0; chunk_idx < FAEST_EM_256F_LAMBDA; chunk_idx += 8) {
+    unsigned int j   = FAEST_EM_256F_R - 1;
+    unsigned int ird = chunk_idx + 32 * FAEST_EM_256F_Nwd * (j + 1);
+    unsigned int r   = chunk_idx % 32 / 8;
+    unsigned int c   = ((chunk_idx - 8 * r) / 32 + r) % FAEST_EM_256F_Nwd;
 
-        if (j < (FAEST_EM_256F_R - 1)) {
-          for (unsigned int i = 0; i < 8; i++) {
-            memcpy(bf_z_tilde + i, get_vole_aes_256(vbb, ird + i), sizeof(bf256_t));
-          }
-        } else {
-          for (unsigned int i = 0; i < 8; ++i) {
-            // Step: 12
-            bf_z_tilde[i] = *get_vole_aes_256(vbb_out, ird - 32 * FAEST_EM_256F_Nwd * (j + 1) + i);
-            if (bf_x) {
-              bf_z_tilde[i] = bf256_add(bf_z_tilde[i], bf_x[ird + i]);
-            }
-          }
-        }
+    if (FAEST_EM_256F_Nwd == 8 && r >= 2) {
+      c = (c + 1 + FAEST_EM_256F_Nwd) % FAEST_EM_256F_Nwd;
+    }
 
-        bf256_t bf_y_tilde[8];
-        for (unsigned int i = 0; i < 8; ++i) {
-          bf_y_tilde[i] = bf256_add(bf256_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
-                                    bf_z_tilde[(i + 2) % 8]);
-        }
-        bf_y_tilde[0] = bf256_add(bf_y_tilde[0], factor);
-        bf_y_tilde[2] = bf256_add(bf_y_tilde[2], factor);
-
-        // Step: 18
-        y_out[4 * FAEST_EM_256F_Nwd * j + 4 * c + r] = bf256_byte_combine(bf_y_tilde);
+    bf256_t bf_z_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_z_tilde[i] = *get_vole_aes_256(vbb_out, chunk_idx + i);
+      if (bf_x) {
+        bf_z_tilde[i] = bf256_add(bf_z_tilde[i], bf_x[ird + i]);
       }
     }
+
+    bf256_t bf_y_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_y_tilde[i] = bf256_add(bf256_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
+                                bf_z_tilde[(i + 2) % 8]);
+    }
+    bf_y_tilde[0] = bf256_add(bf_y_tilde[0], factor);
+    bf_y_tilde[2] = bf256_add(bf_y_tilde[2], factor);
+
+    y_out[4 * FAEST_EM_256F_Nwd * j + 4 * c + r] = bf256_byte_combine(bf_y_tilde);
+  }
+
+  for (unsigned int chunk_idx = FAEST_EM_256F_LAMBDA;
+       chunk_idx < FAEST_EM_256F_R * FAEST_EM_256F_Nwd * 4 * 8; chunk_idx += 8) {
+    unsigned int ird = chunk_idx;
+    unsigned int j   = (ird - FAEST_EM_256F_LAMBDA) / (32 * FAEST_EM_256F_Nwd);
+    unsigned int r   = (ird - FAEST_EM_256F_LAMBDA - j * 32 * FAEST_EM_256F_Nwd) % 32 / 8;
+    unsigned int c = ((ird - FAEST_EM_256F_LAMBDA - j * 32 * FAEST_EM_256F_Nwd - 8 * r) / 32 + r) %
+                     FAEST_EM_256F_Nwd;
+
+    if (FAEST_EM_256F_Nwd == 8 && r >= 2) {
+      c = (c + 1 + FAEST_EM_256F_Nwd) % FAEST_EM_256F_Nwd;
+    }
+
+    bf256_t bf_z_tilde[8];
+    for (unsigned int i = 0; i < 8; i++) {
+      memcpy(bf_z_tilde + i, get_vole_aes_256(vbb, chunk_idx + i), sizeof(bf256_t));
+    }
+
+    bf256_t bf_y_tilde[8];
+    for (unsigned int i = 0; i < 8; ++i) {
+      bf_y_tilde[i] = bf256_add(bf256_add(bf_z_tilde[(i + 7) % 8], bf_z_tilde[(i + 5) % 8]),
+                                bf_z_tilde[(i + 2) % 8]);
+    }
+    bf_y_tilde[0] = bf256_add(bf_y_tilde[0], factor);
+    bf_y_tilde[2] = bf256_add(bf_y_tilde[2], factor);
+
+    y_out[4 * FAEST_EM_256F_Nwd * j + 4 * c + r] = bf256_byte_combine(bf_y_tilde);
   }
 }
 
@@ -2474,7 +2520,7 @@ static void em_enc_constraints_Mkey_0_256(const uint8_t* out, const uint8_t* x, 
   em_enc_forward_256_1(w, x, bf_s);
   em_enc_forward_256_vbb(vbb, NULL, bf_vs);
   em_enc_backward_256_1(w, x, w_out, bf_s_dash);
-  em_enc_backward_256_vbb(vbb, NULL, vbb, 1, 0, NULL, bf_vs_dash);
+  em_enc_backward_256_vbb_linear_access(vbb, NULL, vbb, 1, 0, NULL, bf_vs_dash);
 
   for (unsigned int j = 0; j < FAEST_EM_256F_Senc; j++) {
     const bf256_t tmp = bf256_mul(bf_vs[j], bf_vs_dash[j]);

--- a/vbb.c
+++ b/vbb.c
@@ -446,7 +446,12 @@ static inline uint8_t* get_vole_aes(vbb_t* vbb, unsigned int idx) {
 
 #if ACCESS_PATTERN_TEST
   // Store the idx value in a file
-  FILE* file = fopen("access_pattern.txt", "a");
+  FILE* file;
+  if (vbb->party == VERIFIER) {
+    file = fopen("access_pattern_verifier.txt", "a");
+  } else {
+    file = fopen("access_pattern_prover.txt", "a");
+  }
   fprintf(file, "%d\n", idx);
   fclose(file);
 #endif

--- a/vbb.c
+++ b/vbb.c
@@ -96,9 +96,9 @@ void prepare_hash_sign(vbb_t* vbb) {
 void prepare_aes_sign(vbb_t* vbb) {
   if (vbb->full_size) {
     vbb->cache_idx = 0;
-    return;
+  } else {
+    recompute_aes_sign(vbb, 0, vbb->row_count);
   }
-  recompute_aes_sign(vbb, 0, vbb->row_count);
   setup_vk_cache(vbb);
 }
 
@@ -399,10 +399,9 @@ void prepare_aes_verify(vbb_t* vbb) {
   if (vbb->full_size) {
     apply_witness_values_cmo(vbb);
     vbb->cache_idx = 0;
-    return;
+  } else {
+    recompute_aes_verify(vbb, 0, vbb->row_count);
   }
-
-  recompute_aes_verify(vbb, 0, vbb->row_count);
   setup_vk_cache(vbb);
 }
 
@@ -538,9 +537,6 @@ static void setup_vk_cache(vbb_t* vbb) {
 
 static inline uint8_t* get_vk(vbb_t* vbb, unsigned int idx) {
   assert(idx < vbb->params->faest_param.Lke);
-  if (vbb->full_size) {
-    return get_vole_aes(vbb, idx);
-  }
   unsigned int offset = idx * (vbb->params->faest_param.lambda / 8);
   return (vbb->vk_cache + offset);
 }


### PR DESCRIPTION
Fix vole access pattern for EM mode variants.
Use vk cache even when vole cache is full size to avoid excessive transposing.